### PR TITLE
Hamburger menu Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
     "test": "tsx ./quartz/util/path.test.ts && tsx ./quartz/depgraph.test.ts",
-    "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
+    "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1",
+    "dev": "npx quartz build --serve"
   },
   "engines": {
     "npm": ">=9.3.1",

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -5,16 +5,20 @@ import * as Component from "./quartz/components"
 export const sharedPageComponents: SharedLayout = {
   navbar: [
     Component.PageTitle(),
-    Component.MobileOnly(Component.Spacer()),
-    Component.NavigationLinks({
-      links: {
-        Blogs: "/blogs",
-        Github: "https://github.com/PrathameshDhande22/Java-Tutorial",
-        "About Me": "https://github.com/PrathameshDhande22"
-      }
-    }),
-    Component.Darkmode(),
-    Component.Search()
+    Component.NavbarWrapper({
+      components: [
+        Component.MobileOnly(Component.Spacer()),
+        Component.NavigationLinks({
+          links: {
+            Blogs: "/blogs",
+            Github: "https://github.com/PrathameshDhande22/Java-Tutorial",
+            "About Me": "https://github.com/PrathameshDhande22"
+          }
+        }),
+        Component.Search(),
+        Component.Darkmode()
+      ]
+    })
   ],
   head: Component.Head(),
   header: [Component.MobileOnly(

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -13,7 +13,8 @@ export const sharedPageComponents: SharedLayout = {
         "About Me": "https://github.com/PrathameshDhande22"
       }
     }),
-    Component.Darkmode()
+    Component.Darkmode(),
+    Component.Search()
   ],
   head: Component.Head(),
   header: [Component.MobileOnly(

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -16,11 +16,8 @@ export const sharedPageComponents: SharedLayout = {
     Component.Darkmode()
   ],
   head: Component.Head(),
-  header: [
-
-  ],
-  afterBody: [
-  ],
+  header: [],
+  afterBody: [],
   footer: Component.Footer({
     links: {
       GitHub: "https://prathameshdhande22.github.io/Java-Tutorial/",
@@ -32,7 +29,6 @@ export const sharedPageComponents: SharedLayout = {
 // components for pages that display a single page (e.g. a single note)
 export const defaultContentPageLayout: PageLayout = {
   beforeBody: [
-
     Component.Breadcrumbs(),
     Component.ArticleTitle(),
     Component.ContentMeta(),
@@ -40,7 +36,13 @@ export const defaultContentPageLayout: PageLayout = {
   ],
   left: [
     Component.MobileOnly(
-      Component.Drawer()
+      Component.Drawer({
+        links: {
+          Blogs: "/blogs",
+          Github: "https://github.com/PrathameshDhande22/Java-Tutorial",
+          "About Me": "https://github.com/PrathameshDhande22"
+        }
+      })
     ),
     Component.Search(),
     Component.DesktopOnly(

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -16,7 +16,15 @@ export const sharedPageComponents: SharedLayout = {
     Component.Darkmode()
   ],
   head: Component.Head(),
-  header: [],
+  header: [Component.MobileOnly(
+    Component.Drawer({
+      links: {
+        Blogs: "/blogs",
+        Github: "https://github.com/PrathameshDhande22/Java-Tutorial",
+        "About Me": "https://github.com/PrathameshDhande22"
+      }
+    })
+  )],
   afterBody: [],
   footer: Component.Footer({
     links: {
@@ -35,15 +43,6 @@ export const defaultContentPageLayout: PageLayout = {
     Component.TagList(),
   ],
   left: [
-    Component.MobileOnly(
-      Component.Drawer({
-        links: {
-          Blogs: "/blogs",
-          Github: "https://github.com/PrathameshDhande22/Java-Tutorial",
-          "About Me": "https://github.com/PrathameshDhande22"
-        }
-      })
-    ),
     Component.Search(),
     Component.DesktopOnly(
       Component.Explorer({

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -44,7 +44,6 @@ export const defaultContentPageLayout: PageLayout = {
     Component.TagList(),
   ],
   left: [
-    Component.Search(),
     Component.DesktopOnly(
       Component.Explorer({
         title: "Patterns",

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -39,6 +39,9 @@ export const defaultContentPageLayout: PageLayout = {
     Component.TagList(),
   ],
   left: [
+    Component.MobileOnly(
+      Component.Drawer()
+    ),
     Component.Search(),
     Component.DesktopOnly(
       Component.Explorer({

--- a/quartz/components/Drawer.tsx
+++ b/quartz/components/Drawer.tsx
@@ -1,0 +1,18 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import style from "./styles/drawer.scss"
+// @ts-ignore
+
+interface Options {
+  links?: Record<string, string>
+}
+
+export default ((opts?: Options) => {
+  const Drawer: QuartzComponent = (props: QuartzComponentProps) => {
+    const links = opts?.links ?? []
+    return <div class="drawer">Drawer</div>
+  }
+
+  Drawer.css = style
+
+  return Drawer
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/Drawer.tsx
+++ b/quartz/components/Drawer.tsx
@@ -9,7 +9,19 @@ interface Options {
 export default ((opts?: Options) => {
   const Drawer: QuartzComponent = (props: QuartzComponentProps) => {
     const links = opts?.links ?? []
-    return <div class="drawer">Drawer</div>
+    return (
+      <div class="drawer">
+        <div class="drawer-wrapper">
+          <ul class="links">
+            {Object.entries(links).map(([text, link]) => (
+              <li>
+                <a href={link}>{text}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    )
   }
 
   Drawer.css = style

--- a/quartz/components/Drawer.tsx
+++ b/quartz/components/Drawer.tsx
@@ -1,17 +1,26 @@
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import style from "./styles/drawer.scss"
 // @ts-ignore
+import script from "./scripts/drawer.inline"
+import TableOfContents from "./TableOfContents"
+import { classNames } from "../util/lang"
+import { FileNode } from "./ExplorerNode"
+import { resolveRelative } from "../util/path"
 
 interface Options {
   links?: Record<string, string>
 }
 
 export default ((opts?: Options) => {
-  const Drawer: QuartzComponent = (props: QuartzComponentProps) => {
+  const Drawer: QuartzComponent = ({ displayClass, fileData, allFiles }: QuartzComponentProps) => {
     const links = opts?.links ?? []
+    const fileTree = new FileNode("")
+    allFiles.forEach((file) => fileTree.add(file))
+
     return (
       <div class="drawer">
         <div class="drawer-wrapper">
+          <h3 class="drawer-title">MENU</h3>
           <ul class="links">
             {Object.entries(links).map(([text, link]) => (
               <li>
@@ -19,12 +28,49 @@ export default ((opts?: Options) => {
               </li>
             ))}
           </ul>
+          <div class={classNames(displayClass, "toc")}>
+            <button
+              type="button"
+              id="toc"
+              class={fileData.collapseToc ? "collapsed" : ""}
+              aria-controls="toc-content"
+              aria-expanded={!fileData.collapseToc}
+            >
+              <h3>Patterns</h3>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="fold"
+              >
+                <polyline points="6 9 12 15 18 9"></polyline>
+              </svg>
+            </button>
+            <div id="toc-content" class={fileData.collapseToc ? "collapsed" : ""}>
+              <ul class="overflow">
+                {allFiles.map((value) => {
+                  return (
+                    <li key={value.slug}>
+                      <a href={resolveRelative(value.slug!, value.slug!)} data-for={value.slug}>{value.frontmatter?.title}</a>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
     )
   }
 
   Drawer.css = style
+  Drawer.afterDOMLoaded = script
 
   return Drawer
 }) satisfies QuartzComponentConstructor

--- a/quartz/components/NavbarWrapper.tsx
+++ b/quartz/components/NavbarWrapper.tsx
@@ -1,0 +1,26 @@
+import { concatenateResources } from "../util/resources"
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import style from "./styles/navbarwrapper.scss"
+interface Options {
+  components: QuartzComponent[]
+}
+
+export default ((opts: Options) => {
+  const NavbarWrapper: QuartzComponent = (props: QuartzComponentProps) => {
+    return (
+      <div class="navbar-wrapper">
+        {opts?.components.map((Component) => {
+          return <Component {...props}></Component>
+        })}
+      </div>
+    )
+  }
+  NavbarWrapper.afterDOMLoaded = concatenateResources(
+    ...opts.components.map((c) => c.afterDOMLoaded),
+  )
+  NavbarWrapper.beforeDOMLoaded = concatenateResources(
+    ...opts.components.map((c) => c.beforeDOMLoaded),
+  )
+  NavbarWrapper.css = concatenateResources(...opts.components.map((c) => c.css), style)
+  return NavbarWrapper
+}) satisfies QuartzComponentConstructor<Options>

--- a/quartz/components/NavigationLinks.tsx
+++ b/quartz/components/NavigationLinks.tsx
@@ -11,9 +11,30 @@ interface Options {
 export default ((opts?: Options) => {
   const NavigationLinks: QuartzComponent = (props: QuartzComponentProps) => {
     const links = opts?.links ?? []
+    let crossactive = false
+
     return (
       <nav class="nav-links">
-        <button className="menu-btn">Menu</button>
+        <button className="menu-btn">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="hamburger active"
+          >
+            <line x1="4" x2="20" y1="12" y2="12" />
+            <line x1="4" x2="20" y1="6" y2="6" />
+            <line x1="4" x2="20" y1="18" y2="18" />
+          </svg>
+          <svg width="24" height="24" class="cross">
+            <line x1="5" y1="5" x2="19" y2="19" stroke-width="2" />
+            <line x1="19" y1="5" x2="5" y2="19" stroke-width="2" />
+          </svg>
+        </button>
         <ul class="links">
           {Object.entries(links).map(([text, link]) => (
             <li>

--- a/quartz/components/NavigationLinks.tsx
+++ b/quartz/components/NavigationLinks.tsx
@@ -11,8 +11,6 @@ interface Options {
 export default ((opts?: Options) => {
   const NavigationLinks: QuartzComponent = (props: QuartzComponentProps) => {
     const links = opts?.links ?? []
-    let crossactive = false
-
     return (
       <nav class="nav-links">
         <button className="menu-btn">

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -21,10 +21,12 @@ import RecentNotes from "./RecentNotes"
 import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import NavigationLinks from "./NavigationLinks"
+import Drawer from "./Drawer"
 
 export {
   ArticleTitle,
   Content,
+  Drawer,
   TagContent,
   NavigationLinks,
   FolderContent,

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -22,6 +22,7 @@ import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import NavigationLinks from "./NavigationLinks"
 import Drawer from "./Drawer"
+import NavbarWrapper from "./NavbarWrapper"
 
 export {
   ArticleTitle,
@@ -39,6 +40,7 @@ export {
   Explorer,
   TagList,
   Graph,
+  NavbarWrapper,
   Backlinks,
   Search,
   Footer,

--- a/quartz/components/scripts/drawer.inline.ts
+++ b/quartz/components/scripts/drawer.inline.ts
@@ -7,3 +7,8 @@ drawerele?.addEventListener("click", () => {
     const isdrawerActive: boolean = drawerele.classList.contains("active")
     assignActiveClassToDrawerButton(isdrawerActive)
 })
+
+const toccontentele = document.querySelector(".toc")
+toccontentele?.addEventListener("click", (e) => {
+    e.stopPropagation();
+})

--- a/quartz/components/scripts/drawer.inline.ts
+++ b/quartz/components/scripts/drawer.inline.ts
@@ -1,0 +1,9 @@
+import { assignActiveClassToDrawerButton } from "./util"
+
+const drawerele = document.querySelector(".drawer")
+drawerele?.addEventListener("click", () => {
+    drawerele.classList.remove("active")
+
+    const isdrawerActive: boolean = drawerele.classList.contains("active")
+    assignActiveClassToDrawerButton(isdrawerActive)
+})

--- a/quartz/components/scripts/navigationlinks.inline.ts
+++ b/quartz/components/scripts/navigationlinks.inline.ts
@@ -2,4 +2,23 @@ let drawer = document.getElementsByClassName("drawer")[0]
 
 document.getElementsByClassName("menu-btn")[0].addEventListener("click", () => {
     drawer.classList.toggle("active")
+
+    const isdrawerActive: boolean = drawer.classList.contains("active")
+    assignActiveClassToDrawerButton(isdrawerActive)
 })
+
+function assignActiveClassToDrawerButton(isactive: boolean) {
+    const hamburgersvg = document.querySelector(".hamburger")
+
+    const cross = document.querySelector(".cross")
+
+    if (isactive) {
+        cross?.classList.add("active")
+        hamburgersvg?.classList.remove("active")
+
+    } else {
+        cross?.classList.remove("active")
+        hamburgersvg?.classList.add("active")
+
+    }
+}

--- a/quartz/components/scripts/navigationlinks.inline.ts
+++ b/quartz/components/scripts/navigationlinks.inline.ts
@@ -1,5 +1,5 @@
-let links = document.getElementsByClassName("links")[0]
+let drawer = document.getElementsByClassName("drawer")[0]
 
 document.getElementsByClassName("menu-btn")[0].addEventListener("click", () => {
-    links.classList.toggle("active")
+    drawer.classList.toggle("active")
 })

--- a/quartz/components/scripts/navigationlinks.inline.ts
+++ b/quartz/components/scripts/navigationlinks.inline.ts
@@ -1,24 +1,11 @@
+import { assignActiveClassToDrawerButton } from "./util"
+
 let drawer = document.getElementsByClassName("drawer")[0]
 
 document.getElementsByClassName("menu-btn")[0].addEventListener("click", () => {
-    drawer.classList.toggle("active")
+    drawer.classList.add("active")
 
     const isdrawerActive: boolean = drawer.classList.contains("active")
     assignActiveClassToDrawerButton(isdrawerActive)
 })
 
-function assignActiveClassToDrawerButton(isactive: boolean) {
-    const hamburgersvg = document.querySelector(".hamburger")
-
-    const cross = document.querySelector(".cross")
-
-    if (isactive) {
-        cross?.classList.add("active")
-        hamburgersvg?.classList.remove("active")
-
-    } else {
-        cross?.classList.remove("active")
-        hamburgersvg?.classList.add("active")
-
-    }
-}

--- a/quartz/components/scripts/util.ts
+++ b/quartz/components/scripts/util.ts
@@ -43,3 +43,20 @@ export async function fetchCanonical(url: URL): Promise<Response> {
   const [_, redirect] = text.match(canonicalRegex) ?? []
   return redirect ? fetch(`${new URL(redirect, url)}`) : res
 }
+
+export function assignActiveClassToDrawerButton(isactive: boolean) {
+  const hamburgersvg = document.querySelector(".hamburger")
+  const cross = document.querySelector(".cross")
+
+  if (isactive) {
+    cross?.classList.add("active")
+    hamburgersvg?.classList.remove("active")
+    document.body.style.overflow = "hidden"
+    document.body.style.height = "100vh"
+  } else {
+    cross?.classList.remove("active")
+    hamburgersvg?.classList.add("active")
+    document.body.style.overflow = "auto"
+    document.body.style.height = "100%"
+  }
+}

--- a/quartz/components/scripts/util.ts
+++ b/quartz/components/scripts/util.ts
@@ -44,6 +44,16 @@ export async function fetchCanonical(url: URL): Promise<Response> {
   return redirect ? fetch(`${new URL(redirect, url)}`) : res
 }
 
+/**
+ * Toggles the active state of the drawer button and adjusts the document body style.
+ * This function is used to manage the visual state of a hamburger menu or drawer interface.
+ * 
+ * @param isactive - A boolean indicating whether the drawer should be in an active state.
+ *                   If true, the cross icon is shown and the body scroll is disabled.
+ *                   If false, the hamburger icon is shown and the body scroll is enabled.
+ * 
+ * @returns void This function does not return a value.
+ */
 export function assignActiveClassToDrawerButton(isactive: boolean) {
   const hamburgersvg = document.querySelector(".hamburger")
   const cross = document.querySelector(".cross")

--- a/quartz/components/styles/drawer.scss
+++ b/quartz/components/styles/drawer.scss
@@ -2,12 +2,12 @@
 
 .drawer {
     position: fixed;
-    top: 60px;
+    top: 0px;
     right: 0;
     width: 100vw;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
-    height: 90vh;
+    height: 100vh;
     background-color: rgba(0, 0, 0, 0.5);
     color: var(--gray);
     z-index: 600;
@@ -30,12 +30,20 @@
     }
 }
 
+.drawer-title{
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    text-align: center;
+    color: var(--secondary);
+}
+
 .drawer-wrapper {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 80%;
-    height: 90%;
+    width: 70%;
+    height: 85%;
+    padding: 10px 10px 10px 20px;
     background-color: var(--light);
 
     & > .links {
@@ -43,14 +51,13 @@
         flex-direction: column;
         justify-content: center;
         gap: 5px;
-        padding-left: 0;
+        padding: 0;
+        margin: 0;
 
         & > li {
             list-style: none;
-            text-align: center;
             display: inline-block;
             font-size: 18px;
-            padding: 0 6px;
 
             & > a {
                 display: inline-block;

--- a/quartz/components/styles/drawer.scss
+++ b/quartz/components/styles/drawer.scss
@@ -1,0 +1,29 @@
+@use "../../styles/variables.scss" as *;
+
+.drawer {
+    position: fixed;
+    top: 60px;
+    right: 0;
+    width: 100vw;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: var(--gray);
+    z-index: 600;
+    box-shadow:
+        rgba(85, 86, 86, 0.48) 6px 2px 16px 0px,
+        rgba(0, 0, 0, 0.8) -6px -2px 16px 0px;
+
+    &.active {
+        display: block;
+        transform: translateX(0);
+        @media all and ($tablet) {
+            transform: translateX(-100%);
+        }
+
+        @media all and ($desktop) {
+            transform: translateX(-100%);
+        }
+    }
+}

--- a/quartz/components/styles/drawer.scss
+++ b/quartz/components/styles/drawer.scss
@@ -7,16 +7,18 @@
     width: 100vw;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
-    height: 100vh;
+    height: 90vh;
     background-color: rgba(0, 0, 0, 0.5);
     color: var(--gray);
     z-index: 600;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     box-shadow:
         rgba(85, 86, 86, 0.48) 6px 2px 16px 0px,
         rgba(0, 0, 0, 0.8) -6px -2px 16px 0px;
 
     &.active {
-        display: block;
         transform: translateX(0);
         @media all and ($tablet) {
             transform: translateX(-100%);
@@ -24,6 +26,38 @@
 
         @media all and ($desktop) {
             transform: translateX(-100%);
+        }
+    }
+}
+
+.drawer-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 80%;
+    height: 90%;
+    background-color: var(--light);
+
+    & > .links {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 5px;
+        padding-left: 0;
+
+        & > li {
+            list-style: none;
+            text-align: center;
+            display: inline-block;
+            font-size: 18px;
+            padding: 0 6px;
+
+            & > a {
+                display: inline-block;
+                text-decoration: none;
+                color: inherit;
+                padding: 2px 0;
+            }
         }
     }
 }

--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -3,7 +3,8 @@
 
 .navbar {
     position: fixed;
-    top: 0;
+    top: 0px;
+    padding-top: 5px;
     width: 100%;
     display: flex;
     background-color: var(--light);

--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -6,7 +6,6 @@
     top: 0px;
     padding-top: 5px;
     width: 100%;
-    display: flex;
     background-color: var(--light);
     z-index: 100;
 
@@ -21,27 +20,20 @@
         min-width: 95%;
         justify-content: space-between;
         align-items: center;
+        padding: 0px 10px;
 
         @media all and ($mobile) {
             width: 90%;
             gap: 10px;
-            justify-content: flex-end;
+        }
+
+        @media all and (max-width:443px){
+            justify-content: center;
+            margin-bottom: 6px;
         }
 
         @media all and ($tablet) {
             width: 90%;
         }
-
-        & .explorer.mobile-only {
-            position: relative;
-            top: 15px;
-            left: -20px;
-        }
-    }
-}
-
-.left.sidebar {
-    & > .search {
-        padding: 1rem 0 8px;
     }
 }

--- a/quartz/components/styles/navbarwrapper.scss
+++ b/quartz/components/styles/navbarwrapper.scss
@@ -1,0 +1,6 @@
+.navbar-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}

--- a/quartz/components/styles/navigationlinks.scss
+++ b/quartz/components/styles/navigationlinks.scss
@@ -43,23 +43,6 @@
 
         @media all and ($mobile) {
             display: none;
-            flex-direction: column;
-            position: absolute;
-            top: 100%;
-            right: 0;
-            width: 300px;
-            background-color: var(--light);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-            border-radius: 4px;
-            padding: 10px;
-            z-index: 1000;
-        }
-    }
-
-    & ul.active {
-        @media all and ($mobile) {
-            display: flex;
-            border: 2px solid var(--lightgray);
         }
     }
 

--- a/quartz/components/styles/navigationlinks.scss
+++ b/quartz/components/styles/navigationlinks.scss
@@ -1,16 +1,8 @@
 @use "../../styles/variables.scss" as *;
 
 .nav-links {
-    position: absolute;
-    right: 9%;
     display: flex;
-    justify-content: center;
     align-items: center;
-
-    @media all and ($mobile) {
-        position: relative;
-        right: 0;
-    }
 
     & .menu-btn {
         display: none;

--- a/quartz/components/styles/navigationlinks.scss
+++ b/quartz/components/styles/navigationlinks.scss
@@ -14,10 +14,9 @@
 
     & .menu-btn {
         display: none;
-        padding: 5px 20px;
+        padding-top: 5px;
         background-color: var(--light);
-        border: 1px solid var(--tertiary);
-        border-radius: 30px;
+        border: none;
         font-family: var(--bodyFont);
         font-size: 15px;
         outline: none;
@@ -27,10 +26,8 @@
             cursor: pointer;
         }
 
-        &:hover {
-            background-color: var(--tertiary);
-            transition: background-color 0.3s ease-in;
-            color: var(--light);
+        & > .active {
+            display: inline;
         }
     }
 
@@ -75,4 +72,9 @@
     & ul > li > a:hover::after {
         width: 100%;
     }
+}
+.hamburger,
+.cross {
+    stroke: var(--darkgray);
+    display: none;
 }

--- a/quartz/components/types.ts
+++ b/quartz/components/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType, JSX } from "preact"
-import { StaticResources } from "../util/resources"
+import { StaticResources, StringResource } from "../util/resources"
 import { QuartzPluginData } from "../plugins/vfile"
 import { GlobalConfiguration } from "../cfg"
 import { Node } from "hast"
@@ -15,13 +15,13 @@ export type QuartzComponentProps = {
   allFiles: QuartzPluginData[]
   displayClass?: "mobile-only" | "desktop-only"
 } & JSX.IntrinsicAttributes & {
-    [key: string]: any
-  }
+  [key: string]: any
+}
 
 export type QuartzComponent = ComponentType<QuartzComponentProps> & {
-  css?: string
-  beforeDOMLoaded?: string
-  afterDOMLoaded?: string
+  css?: StringResource
+  beforeDOMLoaded?: StringResource
+  afterDOMLoaded?: StringResource
 }
 
 export type QuartzComponentConstructor<Options extends object | undefined = undefined> = (

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -36,17 +36,21 @@ function getComponentResources(ctx: BuildCtx): ComponentResources {
     afterDOMLoaded: new Set<string>(),
   }
 
+  function normalizeResource(resource: string | string[] | undefined): string[] {
+    if (!resource) return []
+    if (Array.isArray(resource)) return resource
+    return [resource]
+  }
+
   for (const component of allComponents) {
     const { css, beforeDOMLoaded, afterDOMLoaded } = component
-    if (css) {
-      componentResources.css.add(css)
-    }
-    if (beforeDOMLoaded) {
-      componentResources.beforeDOMLoaded.add(beforeDOMLoaded)
-    }
-    if (afterDOMLoaded) {
-      componentResources.afterDOMLoaded.add(afterDOMLoaded)
-    }
+    const normalizedCss = normalizeResource(css)
+    const normalizedBeforeDOMLoaded = normalizeResource(beforeDOMLoaded)
+    const normalizedAfterDOMLoaded = normalizeResource(afterDOMLoaded)
+
+    normalizedCss.forEach((c) => componentResources.css.add(c))
+    normalizedBeforeDOMLoaded.forEach((b) => componentResources.beforeDOMLoaded.add(b))
+    normalizedAfterDOMLoaded.forEach((a) => componentResources.afterDOMLoaded.add(a))
   }
 
   return {

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -203,7 +203,7 @@ a {
         height: unset;
         flex-direction: row;
         padding: 0;
-        padding-top: 6rem;
+        padding-top: 4rem;
       }
     }
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -15,8 +15,8 @@ ul.overflow > li:last-of-type {
     margin: 1rem 0 0;
 }
 
-.page-title{
-   @media all and ($mobile){
-    font-size: 1.3rem;
-   }
+.page-title {
+    @media all and ($mobile) {
+        font-size: 1.5rem;
+    }
 }

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,4 +1,5 @@
 @use "./base.scss";
+@use "./variables.scss" as *;
 @import "../components/styles/navbar.scss";
 
 // put your custom CSS here!
@@ -12,4 +13,10 @@ ul.overflow > li:last-of-type {
 
 .article-title {
     margin: 1rem 0 0;
+}
+
+.page-title{
+   @media all and ($mobile){
+    font-size: 1.3rem;
+   }
 }

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -18,7 +18,7 @@ $desktop: "(min-width: #{map.get($breakpoints, desktop)})";
 
 $pageWidth: #{map.get($breakpoints, mobile)};
 $sidePanelWidth: 320px; //380px;
-$topSpacing: 5rem;
+$topSpacing: 6rem;
 $boldWeight: 700;
 $semiBoldWeight: 600;
 $normalWeight: 400;

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -18,7 +18,7 @@ $desktop: "(min-width: #{map.get($breakpoints, desktop)})";
 
 $pageWidth: #{map.get($breakpoints, mobile)};
 $sidePanelWidth: 320px; //380px;
-$topSpacing: 6rem;
+$topSpacing: 5rem;
 $boldWeight: 700;
 $semiBoldWeight: 600;
 $normalWeight: 400;

--- a/quartz/util/resources.tsx
+++ b/quartz/util/resources.tsx
@@ -63,3 +63,10 @@ export interface StaticResources {
   css: CSSResource[]
   js: JSResource[]
 }
+
+export type StringResource = string | string[] | undefined
+export function concatenateResources(...resources: StringResource[]): StringResource {
+  return resources
+    .filter((resource): resource is string | string[] => resource !== undefined)
+    .flat()
+}


### PR DESCRIPTION
Previously, the Navigation Links were made responsive according to Mobile. But they Flickered due to their Fixed width. So, to bypass this, a new Drawer Component was Added. On clicking the Menu button, the Drawer Component will appear from left to right in 0.5 black opacity, making it a backdrop.

### Previously on Clicking Menu Button
![image](https://github.com/user-attachments/assets/8d0f1756-bef4-4e65-ac3b-c448b1285bf8)


### Now New Change - On clicking Menu button Drawer Will Open
![image](https://github.com/user-attachments/assets/f4ae8519-a6b7-4948-a3c0-b0e78f5a1189)

